### PR TITLE
Move cached server to XDG-compliant location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,12 +400,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -417,6 +426,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -615,15 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,7 +832,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -991,9 +1009,9 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "directories",
  "fs_extra",
  "futures",
- "home",
  "rust_search",
  "serde",
  "serde_json",
@@ -1315,11 +1333,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1328,7 +1355,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1337,15 +1379,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1355,9 +1403,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1373,9 +1433,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1385,9 +1457,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ description = "A tool that simplifies installation and running C# language serve
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5", features = ["derive"] }
+directories = "5.0.1"
 fs_extra = "1.3.0"
 futures = "0.3.30"
-home = "0.5.9"
 rust_search = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/download_roslyn.rs
+++ b/src/download_roslyn.rs
@@ -10,16 +10,13 @@ use tokio::process::Command;
 pub async fn ensure_roslyn_is_installed(
     version: &str,
     remove_old_server_versions: bool,
+    cache_dir: &PathBuf,
 ) -> Result<PathBuf> {
-    let mut roslyn_server_dir = home::home_dir().expect("Unable to find home directory");
-    roslyn_server_dir.push(".roslyn");
-    roslyn_server_dir.push("server");
+    let roslyn_server_dir = cache_dir.join("server");
 
-    let mut dll_version_dir = roslyn_server_dir.clone();
-    dll_version_dir.push(version);
+    let dll_version_dir = roslyn_server_dir.join(version);
 
-    let mut dll_path = dll_version_dir.clone();
-    dll_path.push("Microsoft.CodeAnalysis.LanguageServer.dll");
+    let dll_path = dll_version_dir.join("Microsoft.CodeAnalysis.LanguageServer.dll");
 
     if std::path::Path::new(&dll_path).exists() {
         return Ok(dll_path);
@@ -28,11 +25,10 @@ pub async fn ensure_roslyn_is_installed(
     fs_extra::dir::create_all(&roslyn_server_dir, remove_old_server_versions)?;
     fs_extra::dir::create_all(&dll_version_dir, true)?;
 
-    let mut temp_build_dir = temp_dir();
-    temp_build_dir.push("roslyn");
-    fs_extra::dir::create(&temp_build_dir, true)?;
+    let temp_build_root = temp_dir().join("roslyn");
+    fs_extra::dir::create(&temp_build_root, true)?;
 
-    create_csharp_project(&temp_build_dir)?;
+    create_csharp_project(&temp_build_root)?;
 
     Command::new("dotnet")
         .arg("add")
@@ -40,16 +36,17 @@ pub async fn ensure_roslyn_is_installed(
         .arg("Microsoft.CodeAnalysis.LanguageServer.neutral")
         .arg("-v")
         .arg(version)
-        .current_dir(fs::canonicalize(temp_build_dir.clone())?)
+        .current_dir(fs::canonicalize(temp_build_root.clone())?)
         .output()
         .await?;
 
-    temp_build_dir.push("out");
-    temp_build_dir.push("microsoft.codeanalysis.languageserver.neutral");
-    temp_build_dir.push(version);
-    temp_build_dir.push("content");
-    temp_build_dir.push("LanguageServer");
-    temp_build_dir.push("neutral");
+    let temp_build_dir = temp_build_root
+        .join("out")
+        .join("microsoft.codeanalysis.languageserver.neutral")
+        .join(version)
+        .join("content")
+        .join("LanguageServer")
+        .join("neutral");
 
     let copy_options = fs_extra::dir::CopyOptions::default()
         .overwrite(true)


### PR DESCRIPTION
Hey, I'm working on integrating this project into my workflow. This seems like a useful first step, as I like to keep my home directory clean. Please take a look at the "roslyn-language-server.github.com" url included in the commit. It's meant to be a project url.  I use my own domain for this most of the time, but I did not see a website on your GitHub profile, so this is just a suggestion. I think it is only used in url form on macOS.