### PR TITLE
Remove redundant capability hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@ A wrapper around the language server behind the C# Visual Studio Code extension,
 This is more stable and faster than OmniSharp.
 
 This tool works around the quirks of `Microsoft.CodeAnalysis.LanguageServer` in the following way: 
-- Installs `Microsoft.CodeAnalysis.LanguageServer` in `~/.roslyn`
+- Downloads `Microsoft.CodeAnalysis.LanguageServer`
 - Launches `Microsoft.CodeAnalysis.LanguageServer` as a process
 - Passes the provided `unix socket` or named pipe and forwards all communication to `stdio` 
-- Waits for `capabilities` notification from the server, and forces `pull diagnostics` to be available. This forces the server respect clients who do not support dynamic registration of diagnostic capabilities.
 - Waits for an `initialize` notification from the client, and finds relevant `.sln` or `.csproj` files and sends them to the server as a custom `open` notification.
 
 ## Installation
 ### Binaries
-Download the binaries that matches your platform under Releases
+Download the binaries that match your platform under Releases
 
 ### Nix
 If you use `nix`, you can use this repository's `nix flake`. 
@@ -22,7 +21,7 @@ Alternatively, install with `cargo`: `cargo install --git https://github.com/Sof
 ## Usage
 
 ### Helix
-Since `Microsoft.CodeAnalysis.LanguageServer` only supports `pull diagnostics` and Helix does not (yet), you would need to use my branch at `github:sofusa/helix-pull-diagnostics`.
+Since `Microsoft.CodeAnalysis.LanguageServer` only supports `pull diagnostics` and Helix does not [yet](https://github.com/helix-editor/helix/pull/11315), you will need to use my branch: `github:sofusa/helix-pull-diagnostics`.
 
 ```toml
 [language-server.roslyn]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,11 @@ use ::futures::future::try_join;
 use anyhow::{Context, Result};
 use clap::Parser;
 use rust_search::SearchBuilder;
-use serde_json::{json, Value};
+use serde_json::Value;
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt, BufReader};
 
 use roslyn_language_server::{
-    notification::{
-        add_content_length_header, Notification, Params, ProjectParams, SolutionParams,
-    },
+    notification::{Notification, Params, ProjectParams, SolutionParams},
     roslyn::start_roslyn,
     server_version::SERVER_VERSION,
 };
@@ -27,49 +25,17 @@ async fn main() {
     let version = SERVER_VERSION;
 
     let pipe = start_roslyn(version, args.remove_old_server_versions).await;
+    let (server_reader, mut server_writer) = tokio::io::split(pipe);
 
-    let (reader, mut writer) = tokio::io::split(pipe);
-
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
-
-    let stream_to_stdout = async {
-        let mut reader = BufReader::new(reader);
-        loop {
-            let mut buffer = vec![0; 3048];
-            let bytes_read = reader
-                .read(&mut buffer)
-                .await
-                .expect("Unable to read incoming server notification");
-
-            if bytes_read == 0 {
-                break; // EOF reached
-            }
-
-            let notification = String::from_utf8(buffer[..bytes_read].to_vec())
-                .expect("Unable to convert buffer to string");
-
-            if notification.contains("capabilities") {
-                let patched_result_notification = force_pull_diagnostics_hack(&notification)?;
-
-                stdout
-                    .write_all(patched_result_notification.as_bytes())
-                    .await?;
-
-                break;
-            }
-
-            stdout
-                .write_all(&buffer[..bytes_read])
-                .await
-                .expect("Unable to forward client notification to server");
-        }
+    let server_to_stdout = async {
+        let mut reader = BufReader::new(server_reader);
+        let mut stdout = io::stdout();
 
         io::copy(&mut reader, &mut stdout).await
     };
 
-    let stdin_to_stream = async {
-        let mut stdin = BufReader::new(stdin);
+    let stdin_to_server = async {
+        let mut stdin = BufReader::new(io::stdin());
         loop {
             let mut buffer = vec![0; 6000];
             let bytes_read = stdin
@@ -81,7 +47,7 @@ async fn main() {
                 break; // EOF reached
             }
 
-            writer
+            server_writer
                 .write_all(&buffer[..bytes_read])
                 .await
                 .expect("Unable to forward client notification to server");
@@ -100,7 +66,7 @@ async fn main() {
                     let open_solution_notification =
                         create_open_solution_notification(&solution_to_open);
 
-                    writer
+                    server_writer
                         .write_all(open_solution_notification.as_bytes())
                         .await
                         .expect("Unable to send open solution notification to server");
@@ -111,7 +77,7 @@ async fn main() {
                 let project_files = find_extension(&root_path, "csproj");
                 let open_projects_notification = create_open_projects_notification(project_files);
 
-                writer
+                server_writer
                     .write_all(open_projects_notification.as_bytes())
                     .await
                     .expect("Unable to send open projects notification to server");
@@ -119,10 +85,10 @@ async fn main() {
                 break;
             }
         }
-        io::copy(&mut stdin, &mut writer).await
+        io::copy(&mut stdin, &mut server_writer).await
     };
 
-    try_join(stdin_to_stream, stream_to_stdout)
+    try_join(stdin_to_server, server_to_stdout)
         .await
         .expect("Will never finish");
 }
@@ -185,22 +151,4 @@ fn create_open_projects_notification(file_paths: Vec<String>) -> String {
     };
 
     notification.serialize()
-}
-
-fn force_pull_diagnostics_hack(notification: &str) -> Result<String, std::io::Error> {
-    let json_start = notification.find('{').ok_or(std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        "No JSON start found",
-    ))?;
-    let mut parsed_notification: Value = serde_json::from_str(&notification[json_start..])?;
-
-    let diagnostic_provider = json!({
-        "interFileDependencies": true,
-        "workDoneProgress": true,
-        "workspaceDiagnostics": true
-    });
-
-    parsed_notification["result"]["capabilities"]["diagnosticProvider"] = diagnostic_provider;
-
-    Ok(add_content_length_header(&parsed_notification.to_string()))
 }


### PR DESCRIPTION
They fixed the need to force dynamic registration capability for pull diagnostics. This removes the need hack :tada: 